### PR TITLE
27 optionsappendto another container element inside the documentbody arrows rendered in a wrong position

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const createMarker  = (): SVGMarkerElement => {
   /**
    * The below attributes and values are specific to this marker, you'll have to know how markers work
    * to really do something fun. For now you'll have to deal with it manually but I might work on an SVG
-   * marker utility. 
+   * marker utility.
    */
   marker.setAttribute('refX', '5');
   marker.setAttribute('refY', '5');
@@ -201,6 +201,7 @@ If you have an issue with this library or want to contribute, please let me know
 
 ## ⏲ Changelog
 
+- v2.0.4-beta.1: Fixed issue [#27](https://github.com/tarkant/svg-dom-arrows/issues/27) related to positioning relatively to the appendTo element.
 - v2.0.2: Documented the code, added `SvgProportions` type, `recalculate()` method, and improved readme.
 - v2.0.1: Fixed issue with typings not being packaged.
 - v2.0.0a: Rewrote from the ground up the full API and implementation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-dom-arrows",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "Draw an SVG arrow between two DOM elements",
   "keywords": [
     "arrow",

--- a/src/paths/LinePath.ts
+++ b/src/paths/LinePath.ts
@@ -238,9 +238,17 @@ export class LinePath {
     this.containerDiv.style.width = `${width}px`;
     this.containerDiv.style.height = `${height}px`;
 
-    // Take into account the window.page(X|Y)Offset to avoid weird scroll issues
-    this.containerDiv.style.top = `${top + window.pageYOffset}px`;
-    this.containerDiv.style.left = `${left + window.pageXOffset}px`;
+    // Take into account the appendTo element's offset for correct positioning
+    if (this.options.appendTo) {
+      const offsetYAppended = this.options.appendTo.getBoundingClientRect().y;
+      const offsetXAppended = this.options.appendTo.getBoundingClientRect().x;
+      this.containerDiv.style.top = `${top - offsetYAppended}px`;
+      this.containerDiv.style.left = `${left - offsetXAppended}px`;
+    } else {
+      // Take into account the window.page(X|Y)Offset to avoid weird scroll issues
+      this.containerDiv.style.top = `${top + window.pageYOffset}px`;
+      this.containerDiv.style.left = `${left + window.pageXOffset}px`;
+    }
   }
 
   /**

--- a/src/paths/LinePath.ts
+++ b/src/paths/LinePath.ts
@@ -239,7 +239,7 @@ export class LinePath {
     this.containerDiv.style.height = `${height}px`;
 
     // Take into account the appendTo element's offset for correct positioning
-    if (this.options.appendTo) {
+    if (this.options.appendTo && this.options.appendTo !== document.body) {
       const offsetYAppended = this.options.appendTo.getBoundingClientRect().y;
       const offsetXAppended = this.options.appendTo.getBoundingClientRect().x;
       this.containerDiv.style.top = `${top - offsetYAppended}px`;

--- a/src/paths/LinePath.ts
+++ b/src/paths/LinePath.ts
@@ -106,6 +106,7 @@ export class LinePath {
     if (debug) {
       this.svgElement.style.background = 'rgba(128,0,0,.2)';
       this.containerDiv.classList.add('debug');
+      this.containerDiv.style.background = 'rgba(128,128,0,.2)';
     }
 
     this.svgPathLine.setAttribute('style', this.options.style);

--- a/src/tests/LinePath.spec.ts
+++ b/src/tests/LinePath.spec.ts
@@ -1,4 +1,4 @@
-/*import { LinePath } from './../paths/LinePath';
+import { LinePath } from './../paths/LinePath';
 import { PathOptions } from '../models/PathOptions';
 import { JSDOM } from 'jsdom';
 
@@ -29,17 +29,4 @@ test('[LinePath] basic usage', () => {
   console.log(start.outerHTML);
   expect(arrow !== undefined) ;
 });
-*/
-describe('Google', async () => {
 
-  await jestPuppeteer.debug();
-
-  beforeAll(async () => {
-    await page.goto('https://google.com')
-  });
-
-  it('should display "google" text on page', async () => {
-    await expect(page).toMatch('google')
-  });
-
-});


### PR DESCRIPTION
## What's new ✨

Fixed issue [#27](https://github.com/tarkant/svg-dom-arrows/issues/27) related to positioning relatively to the appendTo element.